### PR TITLE
Added code for controller services

### DIFF
--- a/src/nifimcp_server/app.py
+++ b/src/nifimcp_server/app.py
@@ -275,6 +275,7 @@ def register_tools() -> None:
         from .tools import input_ports
         from .tools import output_ports
         from .tools import flow
+        from .tools import controller_services # NEW IMPORT
         logger.info("Successfully imported tool modules.")
 
         # Explicitly call registration functions
@@ -308,10 +309,16 @@ def register_tools() -> None:
             modules_registered.append("output_ports")
         else: logger.warning("register_output_port_tools not found in tools.output_ports")
 
-        if hasattr(flow, 'register_flow_tools'): # NEW REGISTRATION CALL
+        if hasattr(flow, 'register_flow_tools'):
             flow.register_flow_tools(mcp_app)
             modules_registered.append("flow")
         else: logger.warning("register_flow_tools not found in tools.flow")
+
+        # NEW REGISTRATION CALL
+        if hasattr(controller_services, 'register_controller_service_tools'):
+            controller_services.register_controller_service_tools(mcp_app)
+            modules_registered.append("controller_services")
+        else: logger.warning("register_controller_service_tools not found in tools.controller_services")
 
         logger.info(f"Tool registration process completed for modules: {', '.join(modules_registered)}")
 

--- a/src/nifimcp_server/nifi_models.py
+++ b/src/nifimcp_server/nifi_models.py
@@ -95,6 +95,15 @@ class StatusHistoryEntity(BaseModel): pass # NEW (placeholder for now)
 class ConnectionStatisticsDTO(BaseModel): pass # NEW
 class ConnectionStatisticsEntity(BaseModel): pass # NEW
 
+# NEW FOR CONTROLLER SERVICES
+class ControllerServiceDTO(BaseModel): pass
+class ControllerServiceReferencingComponentEntity(BaseModel): pass
+class ControllerServiceReferencingComponentsEntity(BaseModel): pass
+class ControllerServiceRunStatusEntity(BaseModel): pass
+class ControllerServicesEntity(BaseModel): pass
+class ControllerServiceTypesEntity(BaseModel): pass
+class ControllerServiceStatusDTO(BaseModel): pass
+
 # ===================================================================
 # Common/Core DTO Definitions
 # ===================================================================
@@ -146,11 +155,6 @@ class BulletinEntity(BaseModel):
     """Placeholder for BulletinEntity"""
     id: Optional[int] = Field(None)
     message: Optional[str] = Field(None)
-    model_config = {"extra": "allow"}
-
-class ControllerServiceEntity(BaseModel):
-    """Placeholder for ControllerServiceEntity"""
-    id: Optional[str] = Field(None)
     model_config = {"extra": "allow"}
 
 class ParameterContextReferenceEntity(BaseModel):
@@ -811,6 +815,87 @@ class PortEntity(BaseModel):
     model_config = {"populate_by_name": True, "extra": "allow"}
 
 # ===================================================================
+# Controller Service Related Models (NEW SECTION)
+# ===================================================================
+class ControllerServiceStatusDTO(BaseModel):
+    """The status of a controller service."""
+    run_status: Optional[str] = Field(None, alias="runStatus", description="The run status of the controller service (e.g., 'ENABLED', 'DISABLED').")
+    active_thread_count: Optional[int] = Field(None, alias="activeThreadCount", description="The number of active threads for the controller service.")
+    validation_status: Optional[str] = Field(None, alias="validationStatus", description="The validation status of the controller service (e.g., 'VALID', 'INVALID').")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServiceDTO(BaseModel):
+    """The configuration details for a Controller Service."""
+    id: Optional[str] = Field(None, description="The id of the component.")
+    versioned_component_id: Optional[str] = Field(None, alias="versionedComponentId")
+    parent_group_id: Optional[str] = Field(None, alias="parentGroupId")
+    name: Optional[str] = Field(None, description="The name of the controller service.")
+    type: Optional[str] = Field(None, description="The type of the controller service (fully qualified class name).")
+    bundle: Optional[BundleDTO] = Field(None, description="The bundle for the controller service.")
+    comments: Optional[str] = Field(None, description="The comments for the controller service.")
+    state: Optional[str] = Field(None, description="The state of the controller service (e.g., 'ENABLED', 'DISABLED', 'ENABLING', 'DISABLING').")
+    persists_state: Optional[bool] = Field(None, alias="persistsState")
+    restricted: Optional[bool] = Field(None)
+    deprecated: Optional[bool] = Field(None)
+    extension_missing: Optional[bool] = Field(None, alias="extensionMissing")
+    multiple_versions_available: Optional[bool] = Field(None, alias="multipleVersionsAvailable")
+    properties: Optional[Dict[str, Optional[str]]] = Field(None, description="The properties of the controller service.")
+    descriptors: Optional[Dict[str, PropertyDescriptorDTO]] = Field(None, description="The descriptors for the controller service properties.")
+    validation_errors: Optional[List[str]] = Field(None, alias="validationErrors")
+    validation_status: Optional[str] = Field(None, alias="validationStatus")
+    bulletin_level: Optional[str] = Field(None, alias="bulletinLevel")
+    annotation_data: Optional[str] = Field(None, alias="annotationData")
+    referencing_components: Optional[List[ControllerServiceReferencingComponentEntity]] = Field(None, alias="referencingComponents")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServiceEntity(BaseModel):
+    """An entity representing a Controller Service."""
+    revision: Optional[RevisionDTO] = Field(None)
+    id: Optional[str] = Field(None)
+    uri: Optional[HttpUrl] = Field(None)
+    position: Optional[PositionDTO] = Field(None)
+    permissions: Optional[PermissionDTO] = Field(None)
+    bulletins: Optional[List[BulletinEntity]] = Field(None)
+    disconnected_node_acknowledged: Optional[bool] = Field(None, alias="disconnectedNodeAcknowledged")
+    parent_group_id: Optional[str] = Field(None, alias="parentGroupId")
+    component: Optional[ControllerServiceDTO] = Field(None)
+    status: Optional[ControllerServiceStatusDTO] = Field(None)
+    operate_permissions: Optional[PermissionDTO] = Field(None, alias="operatePermissions")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServiceReferencingComponentEntity(BaseModel):
+    """An entity representing a component that references a controller service."""
+    revision: Optional[RevisionDTO] = Field(None)
+    id: Optional[str] = Field(None)
+    permissions: Optional[PermissionDTO] = Field(None)
+    component: Optional[Dict[str, Any]] = Field(None, description="A generic component DTO (Processor, Controller Service, etc.).")
+    operate_permissions: Optional[PermissionDTO] = Field(None, alias="operatePermissions")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServiceReferencingComponentsEntity(BaseModel):
+    """A list of components that reference a controller service."""
+    controller_service_referencing_components: Optional[List[ControllerServiceReferencingComponentEntity]] = Field(None, alias="controllerServiceReferencingComponents")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServiceRunStatusEntity(BaseModel):
+    """Payload for updating the run status of a controller service."""
+    revision: RevisionDTO = Field(description="The revision for this request.")
+    state: str = Field(description="The desired state of the controller service ('ENABLED' or 'DISABLED').")
+    disconnected_node_acknowledged: Optional[bool] = Field(False, alias="disconnectedNodeAcknowledged")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServicesEntity(BaseModel):
+    """Entity for a list of controller services."""
+    controller_services: Optional[List[ControllerServiceEntity]] = Field(None, alias="controllerServices")
+    current_time: Optional[str] = Field(None, alias="currentTime")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+class ControllerServiceTypesEntity(BaseModel):
+    """Entity containing a list of available controller service types."""
+    controller_service_types: Optional[List[DocumentedTypeDTO]] = Field(None, alias="controllerServiceTypes")
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+# ===================================================================
 # Generic Models for NiFi Client
 # ... (NiFiClientCreds, NiFiAuthException, NiFiApiException remain the same) ...
 # ===================================================================
@@ -904,3 +989,13 @@ ConnectionsEntity.model_rebuild()
 ProcessGroupsEntity.model_rebuild()   # NEW
 ProcessorsEntity.model_rebuild()      # NEW
 ProcessGroupContentOverviewDTO.model_rebuild() # NEW
+
+# NEW model_rebuild calls for Controller Services
+ControllerServiceStatusDTO.model_rebuild()
+ControllerServiceDTO.model_rebuild()
+ControllerServiceReferencingComponentEntity.model_rebuild()
+ControllerServiceReferencingComponentsEntity.model_rebuild()
+ControllerServiceRunStatusEntity.model_rebuild()
+ControllerServiceEntity.model_rebuild()
+ControllerServicesEntity.model_rebuild()
+ControllerServiceTypesEntity.model_rebuild()

--- a/src/nifimcp_server/tools/controller_services.py
+++ b/src/nifimcp_server/tools/controller_services.py
@@ -1,0 +1,234 @@
+"""
+MCP Tools for interacting with NiFi Controller Services.
+"""
+import logging
+from typing import Any, Optional, List, Dict
+
+from fastmcp import FastMCP, Context
+try:
+    from fastmcp.exceptions import ToolError
+except ImportError:
+    class ToolError(Exception): pass
+from pydantic import BaseModel, Field
+
+from ..nifi_models import (
+    ControllerServiceEntity,
+    ControllerServicesEntity,
+    ControllerServiceTypesEntity,
+    ControllerServiceDTO,
+    ControllerServiceRunStatusEntity,
+    RevisionDTO,
+    NiFiApiException,
+    NiFiAuthException,
+    DocumentedTypeDTO,
+)
+from ..app import get_session_nifi_client
+
+tool_logger = logging.getLogger(__name__)
+
+# --- Tool Input Models ---
+
+class CreateControllerServiceComponentPayload(BaseModel):
+    type: str = Field(..., description="The fully qualified class name of the controller service type (e.g., 'org.apache.nifi.dbcp.DBCPConnectionPool').")
+    name: str = Field(..., description="The desired name for the new controller service instance.")
+    comments: Optional[str] = Field(None, description="Optional comments for the controller service.")
+
+class CreateControllerServicePayload(BaseModel):
+    parent_group_id: str = Field(..., description="The ID of the process group where the controller service will be created.")
+    component: CreateControllerServiceComponentPayload
+    client_id: Optional[str] = Field(None, description="Optional client ID for the revision.")
+
+class UpdateControllerServiceComponentPayload(BaseModel):
+    name: Optional[str] = Field(None, description="New name for the controller service.")
+    comments: Optional[str] = Field(None, description="New comments for the controller service.")
+    properties: Optional[Dict[str, Optional[str]]] = Field(None, description="Controller service properties to update. Set a value to null or an empty string to clear/reset it.")
+
+class UpdateControllerServicePayload(BaseModel):
+    service_id: str = Field(..., description="The ID of the controller service to update.")
+    component_updates: UpdateControllerServiceComponentPayload
+    client_id: Optional[str] = Field(None, description="Client ID for the revision.")
+    disconnected_node_acknowledged: Optional[bool] = Field(False, description="Acknowledge operation on a disconnected node.")
+
+class UpdateControllerServiceRunStatusPayload(BaseModel):
+    service_id: str = Field(..., description="The ID of the controller service to enable or disable.")
+    state: str = Field(..., description="The desired state ('ENABLED' or 'DISABLED').")
+    client_id: Optional[str] = Field(None, description="Client ID for the revision.")
+    disconnected_node_acknowledged: Optional[bool] = Field(False, description="Acknowledge operation on a disconnected node.")
+
+class DeleteControllerServicePayload(BaseModel):
+    service_id: str = Field(..., description="The ID of the controller service to delete.")
+    client_id: Optional[str] = Field(None, description="Client ID for the revision.")
+    disconnected_node_acknowledged: Optional[bool] = Field(False, description="Acknowledge operation on a disconnected node.")
+
+# --- Tool Implementations ---
+
+async def create_nifi_controller_service_impl(ctx: Context, payload: CreateControllerServicePayload) -> ControllerServiceEntity:
+    """Creates a new NiFi Controller Service within a specified process group."""
+    tool_logger.info(f"Tool 'create_nifi_controller_service' called for parent group {payload.parent_group_id}.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        initial_revision = RevisionDTO(clientId=payload.client_id, version=0)
+        component_dto = ControllerServiceDTO(
+            name=payload.component.name,
+            type=payload.component.type,
+            comments=payload.component.comments
+        )
+        api_payload = ControllerServiceEntity(revision=initial_revision, component=component_dto)
+        
+        created_entity = await nifi_client.create_controller_service(payload.parent_group_id, api_payload)
+        tool_logger.info(f"Successfully created controller service '{created_entity.component.name if created_entity.component else 'N/A'}' with ID: {created_entity.id}")
+        return created_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to create controller service: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in create_nifi_controller_service_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+async def get_nifi_controller_service_details_impl(ctx: Context, service_id: str = Field(..., description="The ID of the controller service to retrieve.")) -> Optional[ControllerServiceEntity]:
+    """Retrieves the details of a specific NiFi Controller Service by its ID."""
+    tool_logger.info(f"Tool 'get_nifi_controller_service_details' called for ID {service_id}.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        service_entity = await nifi_client.get_controller_service(service_id)
+        if service_entity is None:
+            tool_logger.info(f"Controller Service {service_id} not found.")
+            return None
+        tool_logger.info(f"Successfully retrieved details for Controller Service {service_id}.")
+        return service_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to get controller service details: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in get_nifi_controller_service_details_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+async def update_nifi_controller_service_impl(ctx: Context, payload: UpdateControllerServicePayload) -> ControllerServiceEntity:
+    """Updates an existing NiFi Controller Service. Fetches the latest revision internally."""
+    tool_logger.info(f"Tool 'update_nifi_controller_service' called for ID {payload.service_id}.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        current_entity = await nifi_client.get_controller_service(payload.service_id)
+        if not current_entity or not current_entity.revision or not current_entity.component:
+            raise ToolError(f"Controller Service {payload.service_id} not found or has no revision/component data.")
+
+        latest_revision = current_entity.revision
+        if payload.client_id:
+            latest_revision.client_id = payload.client_id
+        
+        updated_component_dto = current_entity.component.model_copy(deep=True)
+        update_data = payload.component_updates.model_dump(exclude_unset=True)
+        for field_name, value in update_data.items():
+            setattr(updated_component_dto, field_name, value)
+
+        api_payload = ControllerServiceEntity(
+            revision=latest_revision,
+            component=updated_component_dto,
+            id=payload.service_id,
+            disconnectedNodeAcknowledged=payload.disconnected_node_acknowledged
+        )
+        if api_payload.component:
+            api_payload.component.id = payload.service_id
+
+        updated_entity = await nifi_client.update_controller_service(payload.service_id, api_payload)
+        tool_logger.info(f"Successfully updated controller service {payload.service_id}.")
+        return updated_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to update controller service: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in update_nifi_controller_service_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+async def update_nifi_controller_service_run_status_impl(ctx: Context, payload: UpdateControllerServiceRunStatusPayload) -> ControllerServiceEntity:
+    """Updates the run status of a Controller Service (enables or disables it)."""
+    tool_logger.info(f"Tool 'update_nifi_controller_service_run_status' called for ID {payload.service_id} to state {payload.state}.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        current_entity = await nifi_client.get_controller_service(payload.service_id)
+        if not current_entity or not current_entity.revision:
+            raise ToolError(f"Controller Service {payload.service_id} not found or has no revision.")
+
+        latest_revision = current_entity.revision
+        if payload.client_id:
+            latest_revision.client_id = payload.client_id
+        
+        run_status_payload = ControllerServiceRunStatusEntity(
+            revision=latest_revision,
+            state=payload.state.upper(),
+            disconnectedNodeAcknowledged=payload.disconnected_node_acknowledged
+        )
+        updated_entity = await nifi_client.update_controller_service_run_status(payload.service_id, run_status_payload)
+        tool_logger.info(f"Successfully updated run status for controller service {payload.service_id} to {payload.state}.")
+        return updated_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to update run status: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in update_nifi_controller_service_run_status_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+async def delete_nifi_controller_service_impl(ctx: Context, payload: DeleteControllerServicePayload) -> ControllerServiceEntity:
+    """Deletes a NiFi Controller Service. Fetches the latest revision internally."""
+    tool_logger.info(f"Tool 'delete_nifi_controller_service' called for ID {payload.service_id}.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        current_entity = await nifi_client.get_controller_service(payload.service_id)
+        if not current_entity or not current_entity.revision or current_entity.revision.version is None:
+            raise ToolError(f"Controller Service {payload.service_id} not found or has no revision version.")
+
+        version_str = str(current_entity.revision.version)
+        effective_client_id = payload.client_id or current_entity.revision.client_id
+
+        deleted_entity = await nifi_client.delete_controller_service(
+            service_id=payload.service_id,
+            version=version_str,
+            client_id=effective_client_id,
+            disconnected_node_acknowledged=payload.disconnected_node_acknowledged
+        )
+        tool_logger.info(f"Successfully deleted controller service {payload.service_id}.")
+        return deleted_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to delete controller service: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in delete_nifi_controller_service_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+async def list_nifi_controller_services_in_group_impl(ctx: Context, process_group_id: str = Field(..., description="The ID of the process group for which to list controller services.")) -> ControllerServicesEntity:
+    """Lists all controller services within a specified process group."""
+    tool_logger.info(f"Tool 'list_nifi_controller_services_in_group' called for PG ID {process_group_id}.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        services_entity = await nifi_client.get_controller_services_in_group(process_group_id)
+        if services_entity is None:
+            return ControllerServicesEntity(controllerServices=[])
+        return services_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to list controller services: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in list_nifi_controller_services_in_group_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+async def list_nifi_available_controller_service_types_impl(ctx: Context) -> ControllerServiceTypesEntity:
+    """Retrieves the types of controller services that this NiFi supports."""
+    tool_logger.info("Tool 'list_nifi_available_controller_service_types' called.")
+    try:
+        nifi_client = await get_session_nifi_client(ctx)
+        types_entity = await nifi_client.get_available_controller_service_types()
+        if types_entity is None:
+            return ControllerServiceTypesEntity(controllerServiceTypes=[])
+        return types_entity
+    except (NiFiAuthException, NiFiApiException) as e:
+        raise ToolError(f"Failed to list available controller service types: {e.message if hasattr(e, 'message') else str(e)}") from e
+    except Exception as e:
+        tool_logger.exception(f"Unexpected error in list_nifi_available_controller_service_types_impl: {e}")
+        raise ToolError(f"An unexpected error occurred: {str(e)}")
+
+# --- Tool Registration ---
+def register_controller_service_tools(app: FastMCP):
+    """Registers controller service tools with the FastMCP app."""
+    tool_logger.info("Registering Controller Service tools...")
+    app.tool(name="create_nifi_controller_service")(create_nifi_controller_service_impl)
+    app.tool(name="get_nifi_controller_service_details")(get_nifi_controller_service_details_impl)
+    app.tool(name="update_nifi_controller_service")(update_nifi_controller_service_impl)
+    app.tool(name="update_nifi_controller_service_run_status")(update_nifi_controller_service_run_status_impl)
+    app.tool(name="delete_nifi_controller_service")(delete_nifi_controller_service_impl)
+    app.tool(name="list_nifi_controller_services_in_group")(list_nifi_controller_services_in_group_impl)
+    app.tool(name="list_nifi_available_controller_service_types")(list_nifi_available_controller_service_types_impl)
+    tool_logger.info("Controller Service tools registration complete.")


### PR DESCRIPTION
- src/nifimcp_server/nifi_models.py (Modified):
  Added a comprehensive set of Pydantic models for Controller Services, replacing the previous placeholder. This includes ControllerServiceEntity, ControllerServiceDTO, ControllerServiceRunStatusEntity, ControllerServicesEntity, and ControllerServiceTypesEntity.
  Ensured all forward references were resolved by adding model_rebuild() calls for the new models.

- src/nifimcp_server/nifi_api_client.py (Modified):
  Added a new section of methods to the NiFiApiClient class dedicated to Controller Service endpoints.
  Implemented functions for all required API calls: create, get, update, delete, update_run_status, list_in_group, and get_available_types.

- src/nifimcp_server/tools/controller_services.py (New File):
  Created a new, dedicated tools module for all Controller Service operations.
  Each tool provides a simplified Pydantic payload for the LLM and handles the complexity of interacting with the API client, including fetching the latest revision before an update or delete operation.

- src/nifimcp_server/app.py (Modified):
  Integrated the new tools into the server by importing the controller_services module and calling its register_controller_service_tools function within the main register_tools() function.